### PR TITLE
[Neutron] Small fix for Windows Controls buttons

### DIFF
--- a/themes-cores/neutron8.css
+++ b/themes-cores/neutron8.css
@@ -524,7 +524,8 @@ body {
     width: 100%;
     height: 25px;
     background: radial-gradient(var(--themeColor1), var(--themeColor2), transparent 70%);
-    opacity: .1
+    opacity: .1;
+    pointer-events: none;
 }
 
 .winButton__421ed svg * {


### PR DESCRIPTION
currently, the `.typeWindows__421ed::after` selector overlaps the window control buttons on windows (and presumably MacOS). I've added a `pointer-events: none` rule to that class to allow pointer events like clicking to be passed through the element, and to the windows control buttons below it. This resolves a usability issue a user in [`BetterDiscord - #custom-css`](https://discord.com/channels/86004744966914048/123136820409139200) was having (See [this message specifically](https://discord.com/channels/86004744966914048/123136820409139200/1345148094504767568)). I figured this fix was worth upstreaming to the main repository.